### PR TITLE
[Assemble Quadrotors][LQI] solve the LQI gain calculation for desemble mode

### DIFF
--- a/robots/assemble_quadrotors/config/AssembleControl.yaml
+++ b/robots/assemble_quadrotors/config/AssembleControl.yaml
@@ -82,7 +82,7 @@ male:
 
     # LQI gain generator
     lqi:
-      gain_generate_rate: 15.0
+      gain_generate_rate: 0.0
       gyro_moment_compensation: true
       clamp_gain: true
 
@@ -136,7 +136,7 @@ female:
 
     # LQI gain generator
     lqi:
-      gain_generate_rate: 15.0
+      gain_generate_rate: 0.0
       gyro_moment_compensation: true
       clamp_gain: true
 

--- a/robots/assemble_quadrotors/include/assemble_quadrotors/control/assemble_controller.h
+++ b/robots/assemble_quadrotors/include/assemble_quadrotors/control/assemble_controller.h
@@ -65,6 +65,10 @@ namespace aerial_robot_control
     boost::shared_ptr<HydrusTiltedLQIController> dessemble_mode_controller_;
     boost::shared_ptr<FullyActuatedController> assemble_mode_controller_;
 
+    ros::Publisher desired_baselink_rot_pub_;
+
+    bool send_once_flag_;
+
   protected:
     ros::NodeHandle assemble_nh_;
     ros::NodeHandle dessemble_nh_;

--- a/robots/assemble_quadrotors/src/model/assemble_robot_model.cpp
+++ b/robots/assemble_quadrotors/src/model/assemble_robot_model.cpp
@@ -23,8 +23,6 @@ AssembleTiltedRobotModel::AssembleTiltedRobotModel(bool init_with_rosparam,
 
 void AssembleTiltedRobotModel::assemble()
 {
-  assemble_mode_ = true;
-  dessemble_mode_ = false;
   //initialize urdf model
   urdf::Model empty_model;
   aerial_robot_model::RobotModel::setUrdfModel(empty_model);
@@ -39,12 +37,13 @@ void AssembleTiltedRobotModel::assemble()
   initializeRviz("assemble_robot");
   aerial_robot_model::RobotModel::updateRobotModel(); // update robot model instantly
 
+  // switch the model in the end
+  assemble_mode_ = true;
+  dessemble_mode_ = false;
 }
 
 void AssembleTiltedRobotModel::dessemble()
 {
-  assemble_mode_ = false;
-  dessemble_mode_ = true;
   //initialize urdf model
   urdf::Model empty_model;
   aerial_robot_model::RobotModel::setUrdfModel(empty_model);
@@ -58,6 +57,10 @@ void AssembleTiltedRobotModel::dessemble()
   // ROS_INFO("Rotor num is %d",rotor_num);
   initializeRviz("dessemble_robot");
   HydrusTiltedRobotModel::updateRobotModel(); // update robot model instantly
+
+  // switch the mode in the end
+  assemble_mode_ = false;
+  dessemble_mode_ = true;
 }
 
 void AssembleTiltedRobotModel::getParamFromRos()

--- a/robots/hydrus/include/hydrus/hydrus_lqi_controller.h
+++ b/robots/hydrus/include/hydrus/hydrus_lqi_controller.h
@@ -71,6 +71,9 @@ namespace aerial_robot_control
     virtual void controlCore() override;
     virtual void sendCmd() override;
 
+    virtual bool optimalGain();
+    virtual void publishGain();
+
   protected:
 
     boost::shared_ptr<HydrusRobotModel> hydrus_robot_model_;
@@ -105,10 +108,7 @@ namespace aerial_robot_control
 
     virtual void rosParamInit();
 
-    virtual bool optimalGain();
     virtual void clampGain();
-    virtual void publishGain();
-
     virtual void sendFourAxisCommand();
 
     virtual void allocateYawTerm();

--- a/robots/hydrus/include/hydrus/hydrus_tilted_lqi_controller.h
+++ b/robots/hydrus/include/hydrus/hydrus_tilted_lqi_controller.h
@@ -53,6 +53,10 @@ namespace aerial_robot_control
                     double ctrl_loop_rate);
 
     void controlCore() override;
+
+    bool optimalGain() override;
+    void publishGain() override;
+
   protected:
 
     ros::Publisher desired_baselink_rot_pub_;
@@ -62,9 +66,6 @@ namespace aerial_robot_control
 
     double z_limit_;
 
-
-    bool optimalGain() override;
-    void publishGain() override;
     void rosParamInit() override;
 
   };

--- a/robots/hydrus/src/hydrus_lqi_controller.cpp
+++ b/robots/hydrus/src/hydrus_lqi_controller.cpp
@@ -164,6 +164,11 @@ void HydrusLQIController::gainGeneratorFunc()
   ros::NodeHandle control_nh(nh_, "controller");
   ros::NodeHandle lqi_nh(control_nh, "lqi");
   lqi_nh.param("gain_generate_rate", rate, 15.0);
+  if (rate == 0)
+    {
+      // no lopp to get LQI gain
+      return;
+    }
   ros::Rate loop_rate(rate);
 
   while(ros::ok())
@@ -172,7 +177,6 @@ void HydrusLQIController::gainGeneratorFunc()
         {
           if(optimalGain())
             {
-              clampGain();
               publishGain();
             }
           else
@@ -288,6 +292,10 @@ bool HydrusLQIController::optimalGain()
 
   // compensation for gyro moment
   p_mat_pseudo_inv_ = aerial_robot_model::pseudoinverse(P.middleRows(2, lqi_mode_));
+
+  // clamp gain
+  clampGain();
+
   return true;
 }
 

--- a/robots/hydrus/src/hydrus_tilted_lqi_controller.cpp
+++ b/robots/hydrus/src/hydrus_tilted_lqi_controller.cpp
@@ -115,6 +115,10 @@ bool HydrusTiltedLQIController::optimalGain()
 
   // compensation for gyro moment
   p_mat_pseudo_inv_ = aerial_robot_model::pseudoinverse(P.middleRows(2, 4));
+
+  // clamp gain
+  clampGain();
+
   return true;
 }
 


### PR DESCRIPTION
### What is this

The independent thread in LQI controller (for dessemble mode) has a potential bug when the robot model is switched to assemble mode. 
This PR solve this problem by stopping the thread, and calculate the LQI gain for deseemble mode once. 