### PR TITLE
[GA][STM32 Firmware] change the registry of docker image

### DIFF
--- a/.github/workflows/spinal_build.yml
+++ b/.github/workflows/spinal_build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sugihara-16/docker_test/stm32cubeide_1.8.0_build_env:2024-11-03
+      image: ghcr.io/ut-dragon-lab/stm32cubeide_1.8.0_build_env:latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### What is this

The docker image from ut-dragon-lab is now available.
https://github.com/ut-dragon-lab/Spinal_build_docker_image/pkgs/container/stm32cubeide_1.8.0_build_env