### PR TITLE
[Spinal][Servo] Enable direct communication with Dynamixel servo

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/configs/STM32H7_v2/config.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/configs/STM32H7_v2/config.h
@@ -51,7 +51,7 @@
 #define DYNAMIXEL 1
 #define KONDO 0
 //2.1.3.1 Dynamixel Servo Control without external convertor board
-#define DYNAMIXEL_BOARDLESS_CONTROL 1
+#define DYNAMIXEL_BOARDLESS_CONTROL 0
 //2.2 State Estimate
 //2.2.1 Attitude Estimate
 #define ATTITUDE_ESTIMATE_FLAG 1

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/configs/STM32H7_v2/config.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/configs/STM32H7_v2/config.h
@@ -50,7 +50,8 @@
 #define SERVO_FLAG 1
 #define DYNAMIXEL 1
 #define KONDO 0
-
+//2.1.3.1 Dynamixel Servo Control without external convertor board
+#define DYNAMIXEL_BOARDLESS_CONTROL 1
 //2.2 State Estimate
 //2.2.1 Attitude Estimate
 #define ATTITUDE_ESTIMATE_FLAG 1

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/drivers/Dynamixel/dynamixel_serial.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/drivers/Dynamixel/dynamixel_serial.cpp
@@ -31,7 +31,9 @@ void DynamixelSerial::init(UART_HandleTypeDef* huart, osMutexId* mutex)
         /* rx */
   __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
   __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
-  HAL_HalfDuplex_EnableReceiver(huart_);
+  #if DYNAMIXEL_BOARDLESS_CONTROL
+    HAL_HalfDuplex_EnableReceiver(huart_);
+  #endif
   HAL_UART_Receive_DMA(huart, rx_buf_, RX_BUFFER_SIZE);
   rd_ptr_ = 0;
   memset(rx_buf_, 0, sizeof(rx_buf_));
@@ -557,8 +559,8 @@ void DynamixelSerial::transmitInstructionPacket(uint8_t id, uint16_t len, uint8_
 
   /* send data */
 
-#ifdef DYNAMIXLE_BOARDLESS_CONTROL
-  HAL_HalfDuplex_EnableTransmitter(huart_);
+#if DYNAMIXEL_BOARDLESS_CONTROL
+  HAL_HalfDuplex_EnDYNAMIXEL_BOARDLESS_CONTROLableTransmitter(huart_);
   uint8_t ret;
   ret = HAL_UART_Transmit(huart_, transmit_data, transmit_data_index, 10); //timeout: 10 ms. Although we found 2 ms is enough OK for our case by oscilloscope. Large value is better for UART async task in RTOS.
   if(ret == HAL_OK)

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/drivers/Dynamixel/dynamixel_serial.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/servo/drivers/Dynamixel/dynamixel_serial.cpp
@@ -17,7 +17,7 @@ namespace
 void DynamixelSerial::init(UART_HandleTypeDef* huart, osMutexId* mutex)
 {
 	huart_ = huart;
-        mutex_ = mutex;
+  mutex_ = mutex;
 	servo_num_ = 0;
 	set_pos_tick_ = 0;
 	get_pos_tick_ = 0;
@@ -26,14 +26,15 @@ void DynamixelSerial::init(UART_HandleTypeDef* huart, osMutexId* mutex)
 	get_move_tick_ = 0;
 	get_error_tick_ = 0;
 
-        pinReconfig();
+  pinReconfig();
 
         /* rx */
-        __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
-        __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
-        HAL_UART_Receive_DMA(huart, rx_buf_, RX_BUFFER_SIZE);
-        rd_ptr_ = 0;
-        memset(rx_buf_, 0, sizeof(rx_buf_));
+  __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+  __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+  HAL_HalfDuplex_EnableReceiver(huart_);
+  HAL_UART_Receive_DMA(huart, rx_buf_, RX_BUFFER_SIZE);
+  rd_ptr_ = 0;
+  memset(rx_buf_, 0, sizeof(rx_buf_));
 
 	std::fill(servo_.begin(), servo_.end(), ServoData(255));
 
@@ -116,14 +117,17 @@ void DynamixelSerial::init(UART_HandleTypeDef* huart, osMutexId* mutex)
 void DynamixelSerial::pinReconfig()
 {
   while(HAL_UART_DeInit(huart_) != HAL_OK);
-
   /*Change baud rate*/
   huart_->Init.BaudRate = 1000000;
   huart_->Init.WordLength = UART_WORDLENGTH_8B;
   huart_->Init.Parity = UART_PARITY_NONE;
   huart_->Init.Mode = UART_MODE_TX_RX;
-  /*Initialize as async mode*/
+  /*Initialize as halfduplex mode*/
+#if DYNAMIXEL_BOARDLESS_CONTROL
+  while(HAL_HalfDuplex_Init(huart_) != HAL_OK);  
+#else 
   while(HAL_UART_Init(huart_) != HAL_OK);
+#endif
 }
 
 void DynamixelSerial::ping()
@@ -552,11 +556,22 @@ void DynamixelSerial::transmitInstructionPacket(uint8_t id, uint16_t len, uint8_
   transmit_data_index++;
 
   /* send data */
-  // WE;
-  HAL_UART_Transmit(huart_, transmit_data, transmit_data_index, 10); //timeout: 10 ms. Although we found 2 ms is enough OK for our case by oscilloscope. Large value is better for UART async task in RTOS.
-  // RE;
-}
 
+#ifdef DYNAMIXLE_BOARDLESS_CONTROL
+  HAL_HalfDuplex_EnableTransmitter(huart_);
+  uint8_t ret;
+  ret = HAL_UART_Transmit(huart_, transmit_data, transmit_data_index, 10); //timeout: 10 ms. Although we found 2 ms is enough OK for our case by oscilloscope. Large value is better for UART async task in RTOS.
+  if(ret == HAL_OK)
+  {
+    // After transmitting, enable the receiver
+    HAL_HalfDuplex_EnableReceiver(huart_);
+  }
+#else
+// WE; 
+  HAL_UART_Transmit(huart_, transmit_data, transmit_data_index, 10); //timeout: 10 ms. Although we found 2 ms is enough OK for our case by oscilloscope. Large value is better for UART async task in RTOS.
+// RE;
+#endif
+}
 /* Receive status packet to Dynamixel */
 int8_t DynamixelSerial::readStatusPacket(uint8_t status_packet_instruction)
 {


### PR DESCRIPTION
### What is this

This pr provides a basic implementation to enable direct servo control for Dynamixel XL330-M077-T using half-duplex communication without converter board.


### Details
In order to use this feature, pleas select the connection method for Dynamixel servo XL330-M077-T by changing variable `DYNAMIXEL_BOARDLESS_CONTROL = 1` in `config.h` file.
With this PR, you can set torque and watch info from rqt without _Best Technology BTE094 TTL2DXIF_ board.


