### PR TITLE
[spinal][attcontrol] initialize rotor_coef and gimbaldof to (1,0)

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
@@ -13,7 +13,7 @@
 
 #ifdef SIMULATION
 #include <sensor_msgs/JointState.h>
-AttitudeController::AttitudeController(): DELTA_T(0), prev_time_(-1), sim_voltage_(0), gimbal_dof_(0), rotor_coef_(1)
+AttitudeController::AttitudeController(): DELTA_T(0), prev_time_(-1), sim_voltage_(0)
 {
 }
 
@@ -53,9 +53,7 @@ AttitudeController::AttitudeController():
   torque_allocation_matrix_inv_sub_("torque_allocation_matrix_inv", &AttitudeController::torqueAllocationMatrixInvCallback, this),
   offset_rot_sub_("desire_coordinate", &AttitudeController::offsetRotCallback, this ),
   att_control_srv_("set_attitude_control", &AttitudeController::setAttitudeControlCallback, this),
-  esc_telem_pub_("esc_telem", &esc_telem_msg_),
-  gimbal_dof_(0),
-  rotor_coef_(1)
+  esc_telem_pub_("esc_telem", &esc_telem_msg_)
 {
 }
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
@@ -171,8 +171,8 @@ private:
 
   int8_t uav_model_;
   uint16_t motor_number_;
-  uint8_t gimbal_dof_;
-  uint8_t rotor_coef_;
+  uint8_t gimbal_dof_ {0};
+  uint8_t rotor_coef_ {1};
   bool start_control_flag_;
   bool pwm_test_flag_;
   bool integrate_flag_;


### PR DESCRIPTION
### What is this
There was a problem that the miniquadrotor flight in simulation but not in real.
Fixing the code to make miniquadrotor fly in real.


### Details
Just initialize gimbal_dof and rotor_coef to (0,1) for other controller.
For example,  aerial_robot_control/under_actuated_tilted_lqi_controller...
This is because they don't have gimbal_dof publisher and cannot update default value.

