### PR TITLE
[gimbalrotor][spinal][attcontrol] fix IMU error in simulation when calc in fc is true.

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
@@ -542,15 +542,16 @@ void AttitudeController::fourAxisCommandCallback( const spinal::FourAxisCommand 
 
   target_angle_[X] = cmd_msg.angles[0];
   target_angle_[Y] = cmd_msg.angles[1];
-
+  int max_yaw_term_index = max_yaw_term_index_;
+  float max_yaw_thrust_d_gain = thrust_d_gain_[max_yaw_term_index][Z];
   for(int i = 0; i < motor_number_; i++)
     {
       // base thrust is about the z control
       base_thrust_term_[i] = cmd_msg.base_thrust[i];
 
       // reconstruct the pi term for yaw (temporary measure for pwm saturation avoidance)
-      if(max_yaw_term_index_ != -1)
-        extra_yaw_pi_term_[i] = cmd_msg.angles[Z] * thrust_d_gain_[i][Z] / thrust_d_gain_[max_yaw_term_index_][Z];
+      if(max_yaw_term_index != -1)
+        extra_yaw_pi_term_[i] = cmd_msg.angles[Z] * thrust_d_gain_[i][Z] / max_yaw_thrust_d_gain;
     }
 
 #ifndef SIMULATION

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.h
@@ -195,7 +195,7 @@ private:
   float roll_pitch_term_[MAX_MOTOR_NUMBER]; //[N]
   float yaw_term_[MAX_MOTOR_NUMBER]; //[N]
   float extra_yaw_pi_term_[MAX_MOTOR_NUMBER]; //[N]
-  int max_yaw_term_index_;
+  int max_yaw_term_index_{-1};
 
   // Offset Rotation from the control frame to the estimation frame
   ap::Matrix3f offset_rot_;


### PR DESCRIPTION

### What is this

This PR for fixing IMU value error in simulation when calc in fc is true.
I found this error occur only in adding yaw d control.(please check attached video.

https://github.com/user-attachments/assets/94c2cd1f-acb6-4ff9-bf6c-3ede099d0367

)

### Main cause 
553 line in attitude_control.cpp
`      
if(max_yaw_term_index_ != -1){
        extra_yaw_pi_term_[i] = cmd_msg.angles[Z] * thrust_d_gain_[i][Z] / thrust_d_gain_[max_yaw_term_index_][Z];
        printf("extra_yaw_pi_term[%d]: %f\n", i, extra_yaw_pi_term_[i]);// added
      }
`

In this code, we access class member variable(max_yaw_term_index_, thrust_d_gain_ ) in every loop.
So,  when max_yaw_term_index_ is updated to -1 or other wrong int value,  thrust_d_gain_[max_yaw_term_index_][Z] became inf or nan value.

logs
`extra_yaw_pi_term[0]: 0.000947
extra_yaw_pi_term[1]: 0.174319
extra_yaw_pi_term[2]: 0.004737
extra_yaw_pi_term[3]: -inf
extra_yaw_pi_term[4]: -0.004737
extra_yaw_pi_term[5]: -0.175266
extra_yaw_pi_term[6]: -0.000000
extra_yaw_pi_term[7]: 0.175266
[ERROR] [1753876523.453940117, 37.438000000]: IMU plugin receives Nan value in IMU sensors !
`

### Details
add local variable before this loop


### Video

